### PR TITLE
Fix EGC-867

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/api/graduation/service/ReportService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/graduation/service/ReportService.java
@@ -354,7 +354,7 @@ public class ReportService {
     private boolean isValidCutOffCourse(List<StudentCourse> studentCourseList, StudentCourse cutOffCourse) {
         List<StudentCourse> dups = studentCourseList.stream().filter(sc ->
                 StringUtils.equalsIgnoreCase(sc.getCourseCode(), cutOffCourse.getCourseCode()) && StringUtils.equalsIgnoreCase(sc.getCourseLevel(), cutOffCourse.getCourseLevel())
-        ).sorted(Comparator.comparing(StudentCourse::getCompletedCoursePercentage, Comparator.nullsLast(Double::compareTo)).reversed()).toList();
+        ).sorted(Comparator.comparing(StudentCourse::getCompletedCoursePercentage, Comparator.nullsLast(Comparator.reverseOrder()))).toList();
 
         if (!dups.isEmpty()) {
             StudentCourse topMarkCourse = dups.get(0);
@@ -1334,4 +1334,3 @@ public class ReportService {
         return null;
     }
 }
-

--- a/api/src/test/java/ca/bc/gov/educ/api/graduation/service/ReportServiceTest.java
+++ b/api/src/test/java/ca/bc/gov/educ/api/graduation/service/ReportServiceTest.java
@@ -24,6 +24,7 @@ import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.io.BufferedReader;
@@ -123,6 +124,29 @@ public class ReportServiceTest {
 
 		var result = reportService.getStudentsForSchoolNonGradYearEndReport();
 		assertNotNull(result);
+	}
+
+	@Test
+	public void testIsValidCutOffCoursePrefersHighestNonNullPercentage() {
+		StudentCourse nullAttempt = StudentCourse.builder()
+				.courseCode("WH")
+				.courseLevel("12")
+				.sessionDate("2025/08")
+				.completedCoursePercentage(null)
+				.build();
+		StudentCourse passingAttempt = StudentCourse.builder()
+				.courseCode("WH")
+				.courseLevel("12")
+				.sessionDate("2025/06")
+				.completedCoursePercentage(88.0)
+				.build();
+		List<StudentCourse> attempts = List.of(nullAttempt, passingAttempt);
+
+		Boolean passingResult = ReflectionTestUtils.invokeMethod(reportService, "isValidCutOffCourse", attempts, passingAttempt);
+		Boolean nullResult = ReflectionTestUtils.invokeMethod(reportService, "isValidCutOffCourse", attempts, nullAttempt);
+
+		assertTrue(passingResult);
+		assertFalse(nullResult);
 	}
 
 	@Test
@@ -2302,4 +2326,3 @@ public class ReportServiceTest {
 		return sb.toString();
 	}
 }
-


### PR DESCRIPTION
Edge case where: a course is flagged as isCutOffCourse=true, and there are multiple attempts of the same code+level, and one of those attempts has a null completed percentage, and the “null” attempt is considered in the cut‑off comparison. This caused a legit course to be dropped from the course list sent to the report api.